### PR TITLE
Add config for Kafka Connect

### DIFF
--- a/connector_malstrek-sink_config.json
+++ b/connector_malstrek-sink_config.json
@@ -6,7 +6,7 @@
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "topics": "finish-line",
-    "connection.url": "jdbc:mariadb://db:3306/<CHANGEME>",
+    "connection.url": "jdbc:mariadb://db:3306/malstrek",
     "connection.user": "<CHANGEME>",
     "connection.password": "<CHANGEME>",
     "dialect.name": "",

--- a/connector_malstrek-sink_config.json
+++ b/connector_malstrek-sink_config.json
@@ -1,0 +1,20 @@
+{
+  "name": "malstrek-sink",
+  "config": {
+    "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
+    "tasks.max": "1",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "topics": "finish-line",
+    "connection.url": "jdbc:mariadb://db:3306/<CHANGEME>",
+    "connection.user": "<CHANGEME>",
+    "connection.password": "<CHANGEME>",
+    "dialect.name": "",
+    "insert.mode": "insert",
+    "table.name.format": "finishline",
+    "pk.mode": "record_key",
+    "pk.fields": "id",
+    "auto.create": "true",
+    "value.converter.schemas.enable": "true"
+  }
+}


### PR DESCRIPTION
MariaDB will get events from Kafka topic `via` the Kafka Connect. This requires configuring a connector in Kafka

In this PR, Add config for Kafka Connect