### PR TITLE
Add golang-migrate Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:latest
+
+RUN apk update && apk --no-cache add curl unzip
+
+ARG MIGRATE_VERSION=4.18.3
+RUN curl -L "https://github.com/golang-migrate/migrate/releases/download/v${MIGRATE_VERSION}/migrate.linux-arm64.tar.gz" | tar xvz
+
+RUN mv /migrate /usr/local/bin/migrate
+
+COPY ./migrations /migrations
+
+COPY ./migrate/wait-for-mariadb.sh /usr/local/bin/wait-for-mariadb
+RUN chmod +x /usr/local/bin/wait-for-mariadb
+
+ENTRYPOINT ["sh", "/usr/local/bin/wait-for-mariadb", "db", "3306"]
+CMD ["sh"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MYSQL_PASSWORD=<YOUR_USER_PASSWORD>
 ## Run
 
 ```bash
-docker compose up -d
+docker compose up --build -d
 ```
 
 Start bash prompt inside the container

--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,18 @@ services:
       networks:
         - streamer_default
 
+    migrate:
+      build: .
+      depends_on:
+        - db
+      volumes:
+        - ./migrations:/migrations
+      command: ["migrate", "-database", "mysql://$MYSQL_USER:$MYSQL_PASSWORD@tcp(db:3306)/$MYSQL_DATABASE?multiStatements=true", "-path", "/migrations", "up"]
+      # tty: true
+      # stdin_open: true
+      networks:
+        - streamer_default
+
 volumes:
   mariadb_data:
 

--- a/migrate/wait-for-mariadb.sh
+++ b/migrate/wait-for-mariadb.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# wait-for-mariadb.sh
+
+set -e
+
+host="$1"
+port="$2"
+shift 2
+cmd="$@"
+
+until nc -z "$host" "$port"; do
+  >&2 echo "MariaDB is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "MariaDB is up - executing command"
+exec $cmd


### PR DESCRIPTION
Migration should be automated. For this, [golang-migrate](https://github.com/golang-migrate/migrate) will be used

In this PR, Add golang-migrate Docker image

> Because migrate container can execute the migration command sooner than the database is ready, a script will be added that will wait until the database becomes ready