### PR TITLE
Add support for Metabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ MARIADB_ROOT_PASSWORD=<YOUR_ROOT_USER_PASSWORD>
 MYSQL_DATABASE=<DATABASE_NAME>
 MYSQL_USER=<YOUR_USER_NAME>
 MYSQL_PASSWORD=<YOUR_USER_PASSWORD>
+MB_DB_TYPE=postgres
+MB_DB_DBNAME=<METABASE_DATABASE_NAME>
+MB_DB_PORT=5432
+MB_DB_USER=<METABASE_DATABASE_USER>
+MB_DB_PASS=<METABASE_DATABASE_PASSWORD>
+MB_DB_HOST=postgres
+POSTGRES_USER=<METABASE_DATABASE_USER>
+POSTGRES_DB=<METABASE_DATABASE_NAME>
+POSTGRES_PASSWORD=<METABASE_DATABASE_PASSWORD>
 ```
 
 ## Run
@@ -57,4 +66,53 @@ exit
 
 ```bash
 docker compose down
+```
+
+---
+
+## Dashboard
+
+Access the dashboard
+
+```
+http://localhost:3000
+```
+
+### First time
+
+Follow the [instructions](https://www.metabase.com/docs/latest/configuring-metabase/setting-up-metabase) to set it up
+
+### Postgres (backend for Metabase)
+
+Log on to the backend database for troubleshooting
+
+```bash
+docker exec -it postgres /bin/bash
+```
+
+Check version
+
+```bash
+psql --version
+```
+
+```bash
+psql -h postgres -p 5432 -U <METABASE_DATABASE_USER> -d <METABASE_DATABASE_NAME>
+```
+
+Enter `METABASE_DATABASE_PASSWORD` when prompted
+
+(Optional) Check what's in the database
+
+```sql
+\l          -- see a list of databases
+\c postgres -- use database named postgres
+\dt         -- see a list of tables
+\q          -- quit
+```
+
+See data of interest
+
+```sql
+SELECT VERSION();
 ```

--- a/compose.yml
+++ b/compose.yml
@@ -22,6 +22,31 @@ services:
       # stdin_open: true
       networks:
         - streamer_default
+    
+    metabase:
+      image: metabase/metabase:v0.56.8
+      container_name: metabase
+      hostname: metabase
+      volumes:
+        - /dev/urandom:/dev/random:ro
+      ports:
+        - 3000:3000
+      env_file: ".env"
+      networks:
+        - streamer_default
+      healthcheck:
+        test: curl --fail -I http://localhost:3000/api/health || exit 1
+        interval: 15s
+        timeout: 5s
+        retries: 5
+
+    postgres:
+      image: postgres:18.0
+      container_name: postgres
+      hostname: postgres
+      env_file: ".env"
+      networks:
+        - streamer_default
 
 volumes:
   mariadb_data:


### PR DESCRIPTION
In order to display finishers' time on a monitor, a dashboard (Metabase with PostgreSQL as the backend) will be used

In this PR, add support for the dashboard