### PR TITLE
Add TimescaleDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,25 @@ ENTRYPOINT ["sh", "/usr/local/bin/wait-for-mariadb", "db", "3306"]
 CMD ["sh"]
 
 
+# Migration tool for PostgreSQL using golang-migrate
+FROM alpine:3.22.2 AS migrate_tool_postgres
+
+RUN apk update && apk --no-cache add curl unzip
+
+ARG MIGRATE_VERSION=4.18.3
+RUN curl -L "https://github.com/golang-migrate/migrate/releases/download/v${MIGRATE_VERSION}/migrate.linux-arm64.tar.gz" | tar xvz
+
+RUN mv /migrate /usr/local/bin/migrate
+
+COPY ./migrations/postgres /migrations-postgres
+
+COPY ./migrate/wait-for-postgres.sh /usr/local/bin/wait-for-postgres
+RUN chmod +x /usr/local/bin/wait-for-postgres
+
+ENTRYPOINT ["sh", "/usr/local/bin/wait-for-postgres", "malstrek-db", "5432"]
+CMD ["sh"]
+
+
 # Malstrek app
 FROM gradle:8.14.2-jdk17 AS java_build
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Log time of runners at the finish line of a small race. The name comes from mål
 Create `.env` file at the root directory
 
 ```bash
+TIMESCALEDB_HOST=malstrek-db
+TIMESCALEDB_DB=<DATABASE_NAME>
+TIMESCALEDB_USER=<USER_NAME>
+TIMESCALEDB_PASSWORD=<PASSWORD>
+TIMESCALEDB_PORT=5432
+TIMESCALEDB_LOCAL_PORT=<LOCAL_PORT>
 MARIADB_ROOT_PASSWORD=<YOUR_ROOT_USER_PASSWORD>
 MYSQL_DATABASE=<DATABASE_NAME>
 MYSQL_USER=<YOUR_USER_NAME>
@@ -86,6 +92,14 @@ See Configuration Reference for [JDBC Sink Connector](https://docs.confluent.io/
 
 ---
 
+Open Docker Desktop
+
+## First time
+
+```bash
+docker compose up -d
+```
+
 ## Build
 
 Build images (Internet connection required)
@@ -99,7 +113,7 @@ docker compose build
 Run background containers (offline OK)
 
 ```bash
-docker compose up db migrate metabase metabase-db --no-build --pull=never -d
+docker compose up db migrate metabase metabase-db malstrek-db migrate-pg --no-build --pull=never -d
 ```
 
 Run the app

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,36 @@ services:
       networks:
         - streamer_default
     
+    malstrek-db:
+      image: timescale/timescaledb:2.18.0-pg17
+      container_name: malstrek-db
+      hostname: malstrek-db
+      ports:
+        - "${TIMESCALEDB_LOCAL_PORT}:${TIMESCALEDB_PORT}"
+      environment:
+        POSTGRES_DB: ${TIMESCALEDB_DB}
+        POSTGRES_USER: ${TIMESCALEDB_USER}
+        POSTGRES_PASSWORD: ${TIMESCALEDB_PASSWORD}
+      volumes:
+        - malstrek_db_data:/var/lib/postgresql/data
+      networks:
+        - streamer_default
+      restart: always
+
+    migrate-pg:
+      build: 
+        context: .
+        dockerfile: Dockerfile
+        target: migrate_tool_postgres
+      container_name: migrate-pg
+      depends_on:
+        - malstrek-db
+      volumes:
+        - ./migrations/postgres:/migrations-postgres
+      command: ["migrate", "-database", "postgres://${TIMESCALEDB_USER}:${TIMESCALEDB_PASSWORD}@${TIMESCALEDB_HOST}:${TIMESCALEDB_PORT}/${TIMESCALEDB_DB}?sslmode=disable", "-path", "/migrations-postgres", "up"]
+      networks:
+        - streamer_default
+
     malstrek-app:
       build: 
         context: .
@@ -71,6 +101,7 @@ services:
 volumes:
   mariadb_data:
   metabase_db_data:
+  malstrek_db_data:
 
 networks:
   streamer_default:

--- a/migrate/wait-for-postgres.sh
+++ b/migrate/wait-for-postgres.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# wait-for-postgres.sh
+
+set -e
+
+host="$1"
+port="$2"
+shift 2
+cmd="$@"
+
+until nc -z "$host" "$port"; do
+  >&2 echo "PostgreSQL is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "PostgreSQL is up - executing command"
+exec $cmd


### PR DESCRIPTION
In this PR, add support for TimescaleDB. No migration yet. The app will continue to use MariaDB.