### PR TITLE
Update Metabase queries to use TimescaleDB

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -30,7 +30,7 @@ Create a question named "All Finishers"
     CROSS JOIN LATERAL (
         SELECT f.timestamp - s.timestamp AS duration
     ) AS d
-    WHERE NOT f.deleted;
+    WHERE NOT s.deleted AND NOT f.deleted;
     ```
 3. Click on Gear icon next to Visualization button
 4. Next to `duration`, click `...`  

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -19,17 +19,18 @@ Create a question named "All Finishers"
 2. Paste this query
     ```sql
     SELECT
-        DENSE_RANK() OVER (PARTITION BY race_number ORDER BY duration ASC) AS finishers,
+        DENSE_RANK() OVER (PARTITION BY race_number ORDER BY d.duration ASC) AS finishers,
         finisher_id,
         race_number,
         bib_number,
-        SEC_TO_TIME(ROUND((f.timestamp - s.timestamp) / 1000)) AS duration
-    FROM
-        finishers AS f
+        TO_CHAR(d.duration, 'HH24:MI:SS') AS duration,
+        CAST(EXTRACT(EPOCH FROM d.duration) / 60.0 AS NUMERIC) AS minutes -- Explicitly cast to numeric so Metabase can finger-print it
+    FROM finishers AS f
     INNER JOIN starters AS s USING (race_number)
-    WHERE
-        f.deleted <> 1;
-
+    CROSS JOIN LATERAL (
+        SELECT f.timestamp - s.timestamp AS duration
+    ) AS d
+    WHERE NOT f.deleted;
     ```
 3. Click on Gear icon next to Visualization button
 4. Next to `duration`, click `...`  

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -26,11 +26,19 @@ Create a question named "All Finishers"
         TO_CHAR(d.duration, 'HH24:MI:SS') AS duration,
         CAST(EXTRACT(EPOCH FROM d.duration) / 60.0 AS NUMERIC) AS minutes -- Explicitly cast to numeric so Metabase can finger-print it
     FROM finishers AS f
-    INNER JOIN starters AS s USING (race_number)
+    INNER JOIN (
+        -- Isolates exactly one row per race_number using the earliest timestamp
+        SELECT DISTINCT ON (race_number) 
+            race_number, 
+            timestamp
+        FROM starters
+        WHERE NOT deleted
+        ORDER BY race_number, timestamp ASC
+    ) AS s USING (race_number)
     CROSS JOIN LATERAL (
         SELECT f.timestamp - s.timestamp AS duration
     ) AS d
-    WHERE NOT s.deleted AND NOT f.deleted;
+    WHERE NOT f.deleted;
     ```
 3. Click on Gear icon next to Visualization button
 4. Next to `duration`, click `...`  


### PR DESCRIPTION
Previously, the Kafka Connect connectors have been reconfigured to sink data to TimescaleDB.

In this PR, Update Metabase queries to use TimescaleDB

To switch Metabase from MariaDB to TimescaleDB, Settings > Admin Settings > Databases > <DATABASE_NAME> > Edit connection details and reconfigure as PostgreSQL

It also fixes two bugs:
* Ranking got messed up when one active row and one or more soft deleted rows exist for a specific race number in `starters` table
* Ranking got messed up when more than one active row exist for a specific race number in `starters` table

> `CROSS JOIN LATERAL` was introduced to keep `f.timestamp - s.timestamp` from DRY. `EXPLAIN` looks equivalent when compared to the original query