### PR TITLE
Add migrations for compression, indexes and view

### DIFF
--- a/migrations/postgres/000008_reconstruct_compression.down.sql
+++ b/migrations/postgres/000008_reconstruct_compression.down.sql
@@ -1,0 +1,20 @@
+-- 1. Clear out active segmented compression job tracking logs
+SELECT remove_compression_policy('starters', if_exists => TRUE);
+SELECT remove_compression_policy('finishers', if_exists => TRUE);
+
+-- 2. Cleanly revert hypertable storage defaults back to plain configurations
+ALTER TABLE starters SET (
+    timescaledb.compress = true,
+    timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 'timestamp DESC'
+);
+
+ALTER TABLE finishers SET (
+    timescaledb.compress = true,
+    timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 'timestamp DESC'
+);
+
+-- 3. Restore original basic unsegmented policies
+SELECT add_compression_policy('starters', INTERVAL '72 hours', if_not_exists => TRUE);
+SELECT add_compression_policy('finishers', INTERVAL '72 hours', if_not_exists => TRUE);

--- a/migrations/postgres/000008_reconstruct_compression.up.sql
+++ b/migrations/postgres/000008_reconstruct_compression.up.sql
@@ -1,0 +1,20 @@
+-- 1. Strip away old automation policies to unlock hypertable metadata catalog locks
+SELECT remove_compression_policy('starters', if_exists => TRUE);
+SELECT remove_compression_policy('finishers', if_exists => TRUE);
+
+-- 2. Alter columnstore rules to apply optimized segment layouts
+ALTER TABLE starters SET (
+    timescaledb.compress = true,
+    timescaledb.compress_segmentby = 'race_number',
+    timescaledb.compress_orderby = 'timestamp ASC'
+);
+
+ALTER TABLE finishers SET (
+    timescaledb.compress = true,
+    timescaledb.compress_segmentby = 'race_number',
+    timescaledb.compress_orderby = 'timestamp ASC'
+);
+
+-- 3. Spin background automation workers back up safely
+SELECT add_compression_policy('starters', INTERVAL '72 hours', if_not_exists => TRUE);
+SELECT add_compression_policy('finishers', INTERVAL '72 hours', if_not_exists => TRUE);

--- a/migrations/postgres/000009_optimize_indexes.down.sql
+++ b/migrations/postgres/000009_optimize_indexes.down.sql
@@ -1,0 +1,9 @@
+-- Safely remove composite indexes
+DROP INDEX IF EXISTS idx_starters_active_race_time;
+DROP INDEX IF EXISTS idx_finishers_race_deleted_time;
+
+-- Restore original simple indexes
+CREATE INDEX idx_starters_race_number ON starters(race_number);
+CREATE INDEX idx_starters_timestamp ON starters(timestamp);
+CREATE INDEX idx_finishers_race_number ON finishers(race_number);
+CREATE INDEX idx_finishers_timestamp ON finishers(timestamp);

--- a/migrations/postgres/000009_optimize_indexes.up.sql
+++ b/migrations/postgres/000009_optimize_indexes.up.sql
@@ -1,0 +1,12 @@
+-- Clean up old inefficient single-column indexes
+DROP INDEX IF EXISTS idx_starters_race_number;
+DROP INDEX IF EXISTS idx_starters_timestamp;
+DROP INDEX IF EXISTS idx_finishers_race_number;
+DROP INDEX IF EXISTS idx_finishers_timestamp;
+
+-- Create highly optimized composite indexes for uncompressed 72-hour data
+CREATE INDEX idx_starters_active_race_time 
+ON starters (deleted, race_number, timestamp ASC);
+
+CREATE INDEX idx_finishers_race_deleted_time 
+ON finishers (race_number, deleted, timestamp ASC);

--- a/migrations/postgres/000010_create_race_finishers_view.down.sql
+++ b/migrations/postgres/000010_create_race_finishers_view.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS v_race_finishers;

--- a/migrations/postgres/000010_create_race_finishers_view.up.sql
+++ b/migrations/postgres/000010_create_race_finishers_view.up.sql
@@ -1,0 +1,29 @@
+-- Ensure clean creation of the view
+DROP VIEW IF EXISTS v_race_finishers;
+
+CREATE VIEW v_race_finishers AS 
+SELECT
+    -- Generates unique rank per finisher relative to their own race group
+    DENSE_RANK() OVER (PARTITION BY race_number ORDER BY d.duration ASC) AS finishers,
+    finisher_id,
+    race_number,
+    bib_number,
+    TO_CHAR(d.duration, 'HH24:MI:SS') AS duration, 
+    CAST(EXTRACT(EPOCH FROM d.duration) / 60.0 AS NUMERIC) AS minutes, 
+    d.duration AS precise_duration,
+    f.timestamp AS finisher_time
+FROM finishers AS f
+INNER JOIN (
+    -- Isolates the single earliest valid row for races with multi-start records
+    SELECT DISTINCT ON (race_number) 
+        race_number, 
+        timestamp
+    FROM starters
+    WHERE NOT deleted
+    ORDER BY race_number, timestamp ASC
+) AS s USING (race_number)
+CROSS JOIN LATERAL (
+    -- Evaluates interval math safely once per row to ensure optimal query flattening
+    SELECT f.timestamp - s.timestamp AS duration
+) AS d
+WHERE NOT f.deleted;


### PR DESCRIPTION
Previously, Metabase was reconfigured so that it queries from TimescaleDB. This required updating the main query, which uncovered opportunities for some improvements

### Compression policy

The preexisting compression policy would have caused inefficiencies because it was not segmented by race number. Script 8 will do this so that filtering by race number on compressed chunks will be more efficient

The following query was used to test the deploy and rollback scripts:

```sql
SELECT 
    hypertable_name, 
    attname AS column_name, 
    segmentby_column_index, 
    orderby_column_index
FROM timescaledb_information.compression_settings
WHERE hypertable_name IN ('starters', 'finishers');
```

Specifically, `segmentedy_column_index` will be `1` for `race_number` after the deploy script for both `starters` and `finishers` tables

### Indexes

The preexisting indexes were indexing on individual columns. Script 9 will be a composite of three columns, in the order that would optimize the main query

> The order is different between `starters` and `finishers` — this is on purpose

The following query was used to check the result of the deploy and rollback scripts:

```sql
SELECT indexname, indexdef 
FROM pg_indexes 
WHERE tablename IN ('starters', 'finishers');
```

### View

Instead of writing custom query in Metabase, script 10 would expose a view. As an example, it can avoid errors like `Unable to bin Field without a min/max value` related to fingerprinting. Also, because the view will appear as a flattened table to Metabase, Field Filter will be simpler due to predicate pushdown.

The following query was used to verify the result of the deploy and rollback scripts:

```sql
SELECT EXISTS (
    SELECT 1 
    FROM information_schema.views 
    WHERE table_schema = 'public' 
      AND table_name = 'v_race_finishers'
);
```

## Tested

Each script was tested manually and using golang-migrate